### PR TITLE
Custom emoji support

### DIFF
--- a/errorSupport.py
+++ b/errorSupport.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from discord import Color, Embed
+from discord import Color, Embed, utils
 import asyncio
 import requests
 from time import time
@@ -174,9 +174,15 @@ class eSupport:
         return True
 
     async def errorResponse(self, ctx, error, explicit=False):
+        # Attempt to retrieve custom emojis, else use non-custom emojis
+        elist = ctx.guild.emojis
+        emoji_yes = utils.get(elist, name="show_supportBotMessage") or '✅'
+        emoji_no = utils.get(elist, name="dontShow_supportBotMessage") or '❎'
+
         def check(reaction, user):
-            e = str(reaction.emoji)
-            return e == '❎' or e == '✅' and not user == self.bot.user
+            e = reaction.emoji
+
+            return e in (emoji_yes, emoji_no) and not user == self.bot.user
 
         # Output error immediately if explicit.
         if explicit:
@@ -192,8 +198,8 @@ class eSupport:
             await ctx.channel.send(embed=rembed)
 
         else:  # Go through steps if not explicit
-            await ctx.add_reaction("❎")
-            await ctx.add_reaction("✅")
+            await ctx.add_reaction(emoji_yes)
+            await ctx.add_reaction(emoji_no)
             try:
                 reaction, user = await self.bot.wait_for('reaction_add',
                                                          timeout=60.0,
@@ -202,7 +208,7 @@ class eSupport:
                 await ctx.clear_reactions()
             else:
                 await ctx.clear_reactions()
-                if str(reaction.emoji) == '✅':
+                if reaction.emoji == emoji_yes:
                     await ctx.add_reaction("🆗")
                     if error['url'] is not None:
                         rembed = Embed(title=error['title'],


### PR DESCRIPTION
Falls back to non custom emojis if they're not found in the guild. Names are currently non customizable and case-senstive (show_supportBotMessage and dontShow_supportBotMessage).