### PR TITLE
Fix bot owner check

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def is_admin():
         # Is the command user Kodikuu?
         c1 = ctx.author.id == 124207277174423552
         # Is the command user the current bot owner?
-        c2 = ctx.author.id == bot.owner_id
+        c2 = bot.is_owner(ctx.author)
         # Does the command user have the Jedi role?
         c3 = ctx.author.top_role.name == "Jedi"
         # Does the command user have the Parsec Team role?
@@ -133,7 +133,7 @@ async def quit_error(ctx, error):
     if isinstance(error, commands.CheckFailure):
         await ctx.send(f'Only {AppInfo.owner} may shut me down.')
     elif ctx.author.id == bot.owner_id:
-        await ctx.send('Something went very *very* ***wrong.***')
+        await ctx.send('Something went very *very **wrong.***')
 
 # Initialise module classes
 eSupport = errorSupport.eSupport(bot)


### PR DESCRIPTION
Including a meaningless 2 character save in the checkfailure string, very cool